### PR TITLE
Accept  column in idtracker.ai CSVs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # aniread 0.4.0
 
+## Bug fixes
+
+* `read_idtracker()` now accepts both the legacy `seconds` and the newer `time` leading column in idtracker.ai CSV exports (#60).
+
 # aniread 0.3.1
 
 * Adds `read_aniframe` that allows you to read your saved aniframes (in `.parquet` format) back into R!

--- a/R/read_idtracker.R
+++ b/R/read_idtracker.R
@@ -43,7 +43,8 @@ read_idtracker_csv <- function(path, path_probabilities, version = 6) {
     show_col_types = FALSE
   ) |>
     suppressMessages() |>
-    janitor::clean_names()
+    janitor::clean_names() |>
+    rename_idtracker_time_column()
 
   data <- data |>
     tidyr::pivot_longer(
@@ -53,11 +54,10 @@ read_idtracker_csv <- function(path, path_probabilities, version = 6) {
       values_to = "val"
     ) |>
     tidyr::pivot_wider(
-      id_cols = c("seconds", "individual"),
+      id_cols = c("time", "individual"),
       names_from = "coordinate",
       values_from = "val"
     ) |>
-    dplyr::rename(time = "seconds") |>
     dplyr::mutate(individual = factor(.data$individual))
 
   if (!is.null(path_probabilities)) {
@@ -89,7 +89,8 @@ read_idtracker_probabilities <- function(path) {
     show_col_types = FALSE
   ) |>
     suppressMessages() |>
-    janitor::clean_names()
+    janitor::clean_names() |>
+    rename_idtracker_time_column()
 
   data <- data |>
     tidyr::pivot_longer(
@@ -98,8 +99,17 @@ read_idtracker_probabilities <- function(path) {
       names_sep = "(?<=[A-Za-z])(?=[0-9])",
       values_to = "confidence"
     ) |>
-    dplyr::select(-"placeholder") |>
-    dplyr::rename(time = "seconds")
+    dplyr::select(-"placeholder")
+  data
+}
+
+# idtracker.ai renamed the leading time column from `seconds` to `time`
+# in newer releases. Accept either, normalising to `time`.
+#' @keywords internal
+rename_idtracker_time_column <- function(data) {
+  if ("seconds" %in% names(data) && !"time" %in% names(data)) {
+    data <- dplyr::rename(data, time = "seconds")
+  }
   data
 }
 

--- a/tests/testthat/test-read_idtracker.R
+++ b/tests/testthat/test-read_idtracker.R
@@ -20,7 +20,9 @@ test_that("read_idtracker reads CSV with legacy `seconds` column", {
   )
 
   expect_s3_class(result, "aniframe")
-  expect_true(all(c("time", "individual", "x", "y", "confidence") %in% names(result)))
+  expect_true(all(
+    c("time", "individual", "x", "y", "confidence") %in% names(result)
+  ))
   expect_true(is.numeric(result$time))
 })
 
@@ -54,7 +56,9 @@ test_that("read_idtracker reads CSV with renamed `time` column", {
   )
 
   expect_s3_class(result, "aniframe")
-  expect_true(all(c("time", "individual", "x", "y", "confidence") %in% names(result)))
+  expect_true(all(
+    c("time", "individual", "x", "y", "confidence") %in% names(result)
+  ))
   expect_equal(sort(unique(result$time)), c(0.000, 0.036))
   expect_setequal(as.character(unique(result$individual)), c("1", "2"))
 })

--- a/tests/testthat/test-read_idtracker.R
+++ b/tests/testthat/test-read_idtracker.R
@@ -1,0 +1,60 @@
+# Tests for read_idtracker
+#
+# - Reads CSV exports that use the legacy `seconds` time column
+# - Reads CSV exports that use the newer `time` time column (#60)
+# - Probabilities CSV with either column name joins correctly
+
+test_that("read_idtracker reads CSV with legacy `seconds` column", {
+  trajectories <- test_path(
+    "data/idtrackerai/trajectories_csv",
+    "trajectories.csv"
+  )
+  probabilities <- test_path(
+    "data/idtrackerai/trajectories_csv",
+    "id_probabilities.csv"
+  )
+
+  result <- read_idtracker(
+    trajectories,
+    path_probabilities = probabilities
+  )
+
+  expect_s3_class(result, "aniframe")
+  expect_true(all(c("time", "individual", "x", "y", "confidence") %in% names(result)))
+  expect_true(is.numeric(result$time))
+})
+
+test_that("read_idtracker reads CSV with renamed `time` column", {
+  # Synthesise a tiny CSV in the newer format where idtracker.ai renamed
+  # the leading column from `seconds` to `time` (issue #60).
+  trajectories <- tempfile(fileext = ".csv")
+  probabilities <- tempfile(fileext = ".csv")
+  on.exit(unlink(c(trajectories, probabilities)), add = TRUE)
+
+  writeLines(
+    c(
+      "time,x1,y1,x2,y2",
+      "0.000,10.0,20.0,30.0,40.0",
+      "0.036,11.0,21.0,31.0,41.0"
+    ),
+    trajectories
+  )
+  writeLines(
+    c(
+      "time,id_probabilities1,id_probabilities2",
+      "0.000,1.0,1.0",
+      "0.036,1.0,1.0"
+    ),
+    probabilities
+  )
+
+  result <- read_idtracker(
+    trajectories,
+    path_probabilities = probabilities
+  )
+
+  expect_s3_class(result, "aniframe")
+  expect_true(all(c("time", "individual", "x", "y", "confidence") %in% names(result)))
+  expect_equal(sort(unique(result$time)), c(0.000, 0.036))
+  expect_setequal(as.character(unique(result$individual)), c("1", "2"))
+})


### PR DESCRIPTION
## Summary

Closes #60.

idtracker.ai renamed the leading column of trajectories and id_probabilities CSV exports from `seconds` to `time` in newer releases. `read_idtracker()` previously hard-coded `seconds`, which broke on the new format. Normalise both names to `time` via a tiny shared helper, `rename_idtracker_time_column()`, applied right after `janitor::clean_names()` in both `read_idtracker_csv()` and `read_idtracker_probabilities()`. The downstream pivots no longer need the trailing `rename(time = "seconds")` because the column is already `time` by then.

## Test plan

New `tests/testthat/test-read_idtracker.R`:

- [ ] reads the existing fixture (legacy `seconds`) and produces an aniframe with a numeric `time` column
- [ ] reads a synthesised CSV pair (new `time`) and produces the same shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)