### PR TITLE
Handle multi-segment Octron rows via `method` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     vroom
 Suggests:
     arrow,
+    covr,
     curl,
     knitr,
     rhdf5,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # aniread 0.4.0
 
+## New features
+
+* `read_octron()` gains a `method` argument to handle frames where Octron emitted multiple mask segments for the same track (#67). One of `"weighted"` (default; area-weighted mean of position and shape props, sum of areas), `"largest"` (single largest segment per row), or `"segments"` (one row per segment, with a new `segment` identity variable).
+
 # aniread 0.3.1
 
 * Adds `read_aniframe` that allows you to read your saved aniframes (in `.parquet` format) back into R!

--- a/R/read_octron.R
+++ b/R/read_octron.R
@@ -5,13 +5,42 @@
 #' as an aniframe with centroid positions, bounding box corners, and
 #' shape descriptors.
 #'
+#' Newer Octron exports (>= the multi-blob handling in
+#' [OCTRON-GUI #63](https://github.com/OCTRON-tracking/OCTRON-GUI/issues/63))
+#' may emit per-segment columns as tuple-strings, e.g. `"(120.5, 85.3)"`,
+#' when YOLO detects multiple disconnected mask segments belonging to
+#' the same track in a single frame. The `method` argument controls
+#' how those rows are reduced to scalar values, or whether they are
+#' expanded into one row per segment.
+#'
 #' @param path Path to the Octron CSV file.
 #' @param keep_bbox Keep bounding box coordinates? Default FALSE.
+#' @param method Strategy for resolving frames where Octron emitted
+#'   multiple mask segments per track. One of:
+#'   \itemize{
+#'     \item `"weighted"` (default): area-weighted mean across all
+#'       segments per row. `area` becomes the sum of segment areas;
+#'       `orientation` falls back to `"largest"` (circular quantity,
+#'       weighted mean is undefined).
+#'     \item `"largest"`: take values from the single largest segment
+#'       per row.
+#'     \item `"segments"`: expand each multi-segment row into one row
+#'       per segment, adding a `segment` identity variable. Segments
+#'       are not matched across frames, so filtering on `segment` is
+#'       generally not meaningful.
+#'   }
+#'   When the source CSV contains no tuple-valued rows, all three
+#'   methods produce identical numeric output.
 #'
 #' @return An aniframe
 #'
 #' @export
-read_octron <- function(path, keep_bbox = FALSE) {
+read_octron <- function(
+  path,
+  keep_bbox = FALSE,
+  method = c("weighted", "largest", "segments")
+) {
+  method <- match.arg(method)
   validate_files(path)
 
   header <- readLines(path, n = 6)
@@ -44,7 +73,14 @@ read_octron <- function(path, keep_bbox = FALSE) {
       bbox_max_y = "bbox_y_max"
     )
 
+  # Resolve multi-segment (tuple-valued) rows into scalar columns or
+  # explode them into per-segment rows.
+  data <- resolve_octron_segments(data, method)
+
   id_cols <- c("track", "time", "label", "confidence")
+  if (method == "segments") {
+    id_cols <- c(id_cols, "segment")
+  }
   spatial_cols <- c(
     "centroid_x",
     "centroid_y",
@@ -74,12 +110,168 @@ read_octron <- function(path, keep_bbox = FALSE) {
       dplyr::filter(!.data$keypoint %in% c("bbox_min", "bbox_max"))
   }
 
+  variables_what <- c("label", "track", "keypoint")
+  if (method == "segments") {
+    variables_what <- c("label", "track", "segment", "keypoint")
+  }
+
   aniframe::as_aniframe(
     data,
-    variables_what = c("label", "track", "keypoint")
+    variables_what = variables_what
   ) |>
     aniframe::set_metadata(
       source = "octron",
       filename = basename(path)
     )
+}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers for handling Octron's tuple-valued multi-segment rows.
+# ---------------------------------------------------------------------------
+
+#' Resolve multi-segment Octron rows by the selected method
+#' @keywords internal
+resolve_octron_segments <- function(data, method) {
+  tuple_cols <- detect_octron_tuple_cols(data)
+
+  if (method == "segments") {
+    if (length(tuple_cols) > 0) {
+      data <- dplyr::mutate(
+        data,
+        dplyr::across(
+          dplyr::all_of(tuple_cols),
+          \(col) parse_octron_column(col)
+        )
+      )
+      data$segment <- lapply(data[[tuple_cols[1]]], seq_along)
+      data <- tidyr::unnest(
+        data,
+        cols = c(dplyr::all_of(tuple_cols), "segment")
+      )
+    } else {
+      data$segment <- 1L
+    }
+    data$segment <- factor(data$segment)
+    return(data)
+  }
+
+  if (length(tuple_cols) == 0) {
+    return(data)
+  }
+
+  parsed_area <- if ("area" %in% names(data)) {
+    parse_octron_column(data$area)
+  } else {
+    rep(list(1), nrow(data))
+  }
+
+  for (col in tuple_cols) {
+    vals <- parse_octron_column(data[[col]])
+    data[[col]] <- if (method == "weighted") {
+      if (col == "area") {
+        resolve_area_sum(vals)
+      } else if (col == "orientation") {
+        resolve_largest(vals, parsed_area)
+      } else {
+        resolve_weighted(vals, parsed_area)
+      }
+    } else {
+      # method == "largest"
+      resolve_largest(vals, parsed_area)
+    }
+  }
+
+  data
+}
+
+#' Detect columns that contain tuple-strings (e.g. "(120.5, 85.3)")
+#' @keywords internal
+detect_octron_tuple_cols <- function(data) {
+  names(data)[vapply(
+    data,
+    function(col) {
+      is.character(col) && any(startsWith(stats::na.omit(col), "("))
+    },
+    logical(1)
+  )]
+}
+
+#' Parse a column of mixed scalars and tuple-strings into a list of
+#' numeric vectors (one per row).
+#' @keywords internal
+parse_octron_column <- function(col) {
+  if (is.numeric(col)) {
+    return(as.list(col))
+  }
+  lapply(col, function(v) {
+    if (is.na(v)) {
+      return(NA_real_)
+    }
+    if (startsWith(v, "(")) {
+      inner <- gsub("[()]", "", v)
+      parts <- strsplit(inner, ",", fixed = TRUE)[[1]]
+      as.numeric(trimws(parts))
+    } else {
+      as.numeric(v)
+    }
+  })
+}
+
+#' Pick the value of the segment with the largest area per row.
+#' @keywords internal
+resolve_largest <- function(values_list, areas_list) {
+  vapply(
+    seq_along(values_list),
+    function(i) {
+      v <- values_list[[i]]
+      a <- areas_list[[i]]
+      if (length(v) == 0L || all(is.na(v))) {
+        return(NA_real_)
+      }
+      if (length(v) == 1L) {
+        return(as.numeric(v))
+      }
+      idx <- which.max(a)
+      if (length(idx) == 0L) idx <- 1L
+      as.numeric(v[idx])
+    },
+    numeric(1)
+  )
+}
+
+#' Compute the area-weighted mean across segments per row.
+#' Falls back to the arithmetic mean when areas are absent or sum to 0.
+#' @keywords internal
+resolve_weighted <- function(values_list, areas_list) {
+  vapply(
+    seq_along(values_list),
+    function(i) {
+      v <- values_list[[i]]
+      a <- areas_list[[i]]
+      if (length(v) == 0L || all(is.na(v))) {
+        return(NA_real_)
+      }
+      if (length(v) == 1L) {
+        return(as.numeric(v))
+      }
+      total <- sum(a, na.rm = TRUE)
+      if (is.finite(total) && total > 0) {
+        sum(v * a, na.rm = TRUE) / total
+      } else {
+        mean(v, na.rm = TRUE)
+      }
+    },
+    numeric(1)
+  )
+}
+
+#' Sum all segment areas per row (used for `area` under `method = "weighted"`).
+#' @keywords internal
+resolve_area_sum <- function(areas_list) {
+  vapply(
+    areas_list,
+    function(a) sum(a, na.rm = TRUE),
+    numeric(1)
+  )
 }

--- a/R/read_octron.R
+++ b/R/read_octron.R
@@ -163,7 +163,10 @@ resolve_octron_segments <- function(data, method) {
   parsed_area <- if ("area" %in% names(data)) {
     parse_octron_column(data$area)
   } else {
-    rep(list(1), nrow(data))
+    # No `area` column — fall back to NA so resolve_weighted hits its
+    # arithmetic-mean branch and resolve_largest defaults to the first
+    # segment.
+    rep(list(NA_real_), nrow(data))
   }
 
   for (col in tuple_cols) {

--- a/R/read_octron.R
+++ b/R/read_octron.R
@@ -233,7 +233,9 @@ resolve_largest <- function(values_list, areas_list) {
         return(as.numeric(v))
       }
       idx <- which.max(a)
-      if (length(idx) == 0L) idx <- 1L
+      if (length(idx) == 0L) {
+        idx <- 1L
+      }
       as.numeric(v[idx])
     },
     numeric(1)

--- a/man/read_octron.Rd
+++ b/man/read_octron.Rd
@@ -4,12 +4,33 @@
 \alias{read_octron}
 \title{Read Octron Segmentation Data}
 \usage{
-read_octron(path, keep_bbox = FALSE)
+read_octron(
+  path,
+  keep_bbox = FALSE,
+  method = c("weighted", "largest", "segments")
+)
 }
 \arguments{
 \item{path}{Path to the Octron CSV file.}
 
 \item{keep_bbox}{Keep bounding box coordinates? Default FALSE.}
+
+\item{method}{Strategy for resolving frames where Octron emitted
+multiple mask segments per track. One of:
+\itemize{
+\item \code{"weighted"} (default): area-weighted mean across all
+segments per row. \code{area} becomes the sum of segment areas;
+\code{orientation} falls back to \code{"largest"} (circular quantity,
+weighted mean is undefined).
+\item \code{"largest"}: take values from the single largest segment
+per row.
+\item \code{"segments"}: expand each multi-segment row into one row
+per segment, adding a \code{segment} identity variable. Segments
+are not matched across frames, so filtering on \code{segment} is
+generally not meaningful.
+}
+When the source CSV contains no tuple-valued rows, all three
+methods produce identical numeric output.}
 }
 \value{
 An aniframe
@@ -19,4 +40,13 @@ Reads CSV files exported from Octron video segmentation software.
 The function parses the metadata header and returns tracking data
 as an aniframe with centroid positions, bounding box corners, and
 shape descriptors.
+}
+\details{
+Newer Octron exports (>= the multi-blob handling in
+\href{https://github.com/OCTRON-tracking/OCTRON-GUI/issues/63}{OCTRON-GUI #63})
+may emit per-segment columns as tuple-strings, e.g. \code{"(120.5, 85.3)"},
+when YOLO detects multiple disconnected mask segments belonging to
+the same track in a single frame. The \code{method} argument controls
+how those rows are reduced to scalar values, or whether they are
+expanded into one row per segment.
 }

--- a/tests/testthat/test-read_octron.R
+++ b/tests/testthat/test-read_octron.R
@@ -170,3 +170,141 @@ test_that("newer format: row count is correct", {
 
   expect_equal(nrow(result_with_bbox), nrow(result_no_bbox) * 3)
 })
+
+# Tests for multi-segment frames (#67) — Octron emits tuple-strings like
+# "(120.5, 85.3)" in per-segment columns when YOLO detects multiple
+# disconnected mask blobs for the same track in one frame.
+
+# Helper: write a tiny Octron-style CSV with one multi-segment row.
+# Row 1 (frame_idx=1) has two segments with areas (800, 200), so:
+#   weighted weights = (0.8, 0.2)
+#   largest idx = 1 (the segment with area 800)
+write_octron_multi_fixture <- function() {
+  path <- tempfile(fileext = ".csv")
+  writeLines(
+    c(
+      "video_name: test_multi.mp4",
+      "frame_count: 3",
+      "frame_count_analyzed: 3",
+      "video_height: 1000",
+      "video_width: 1000",
+      "created_at: 2025-10-04 09:06:31",
+      "frame_counter,frame_idx,track_id,label,confidence,pos_x,pos_y,bbox_area,bbox_x_min,bbox_x_max,bbox_y_min,bbox_y_max,area,eccentricity,solidity,orientation",
+      "0,0,1,worm,0.9,100.0,200.0,1000.0,80.0,120.0,180.0,220.0,500.0,0.5,0.9,-0.4",
+      paste0(
+        '1,1,1,worm,0.85,',
+        '"(150.0, 200.0)","(250.0, 300.0)",',
+        '"(2000.0, 1000.0)",',
+        '"(120.0, 180.0)","(180.0, 220.0)","(220.0, 280.0)","(280.0, 320.0)",',
+        '"(800.0, 200.0)","(0.4, 0.6)","(0.85, 0.9)","(-0.3, 0.5)"'
+      ),
+      "2,2,1,worm,0.92,300.0,400.0,1200.0,280.0,320.0,380.0,420.0,600.0,0.55,0.88,-0.2"
+    ),
+    path
+  )
+  path
+}
+
+test_that("read_octron(method = 'weighted') area-weights multi-segment rows", {
+  path <- write_octron_multi_fixture()
+  on.exit(unlink(path), add = TRUE)
+
+  result <- read_octron(path, method = "weighted")
+
+  # 3 rows, one per frame, all centroid
+  expect_equal(nrow(result), 3)
+  expect_equal(unique(result$keypoint), factor("centroid"))
+  expect_type(result$x, "double")
+  expect_type(result$y, "double")
+
+  # Multi-segment row resolves to the area-weighted mean.
+  # weights = (800, 200) / 1000 = (0.8, 0.2)
+  multi <- result[result$time == 1, ]
+  expect_equal(multi$x, 150 * 0.8 + 200 * 0.2)
+  # y is reflected: video_height (1000) - resolved_y
+  expect_equal(multi$y, 1000 - (250 * 0.8 + 300 * 0.2))
+  # area becomes the SUM of segment areas under "weighted"
+  expect_equal(multi$area, 1000)
+  expect_equal(multi$eccentricity, 0.4 * 0.8 + 0.6 * 0.2)
+  expect_equal(multi$solidity, 0.85 * 0.8 + 0.9 * 0.2)
+  # orientation is special-cased to "largest" (circular quantity)
+  expect_equal(multi$orientation, -0.3)
+
+  # Scalar rows pass through unchanged (modulo y reflection).
+  scalar <- result[result$time == 0, ]
+  expect_equal(scalar$x, 100)
+  expect_equal(scalar$y, 1000 - 200)
+  expect_equal(scalar$area, 500)
+})
+
+test_that("read_octron(method = 'largest') picks the largest segment", {
+  path <- write_octron_multi_fixture()
+  on.exit(unlink(path), add = TRUE)
+
+  result <- read_octron(path, method = "largest")
+  expect_equal(nrow(result), 3)
+
+  multi <- result[result$time == 1, ]
+  # Segment 1 has area 800 (the larger), so all values come from index 1.
+  expect_equal(multi$x, 150)
+  expect_equal(multi$y, 1000 - 250)
+  expect_equal(multi$area, 800)
+  expect_equal(multi$eccentricity, 0.4)
+  expect_equal(multi$solidity, 0.85)
+  expect_equal(multi$orientation, -0.3)
+})
+
+test_that("read_octron(method = 'segments') expands tuples into separate rows", {
+  path <- write_octron_multi_fixture()
+  on.exit(unlink(path), add = TRUE)
+
+  result <- read_octron(path, method = "segments")
+
+  # Row layout: frame 0 -> 1 row, frame 1 -> 2 rows, frame 2 -> 1 row.
+  expect_equal(nrow(result), 4)
+  expect_true("segment" %in% names(result))
+  expect_s3_class(result$segment, "factor")
+
+  # The two segments at frame 1 expose the original per-segment values.
+  multi <- result[result$time == 1, ]
+  expect_equal(nrow(multi), 2)
+  expect_setequal(multi$x, c(150, 200))
+  expect_setequal(multi$y, c(1000 - 250, 1000 - 300))
+  expect_setequal(multi$area, c(800, 200))
+  expect_setequal(multi$eccentricity, c(0.4, 0.6))
+})
+
+test_that("read_octron `method` defaults to 'weighted'", {
+  path <- write_octron_multi_fixture()
+  on.exit(unlink(path), add = TRUE)
+
+  expect_equal(read_octron(path), read_octron(path, method = "weighted"))
+})
+
+test_that("read_octron rejects unknown `method` values", {
+  path <- write_octron_multi_fixture()
+  on.exit(unlink(path), add = TRUE)
+
+  expect_error(read_octron(path, method = "raw"))
+  expect_error(read_octron(path, method = "median"))
+})
+
+test_that("read_octron handles scalar-only files identically across methods", {
+  path <- test_path("data/octron", "octron_sample.csv")
+
+  weighted <- read_octron(path, method = "weighted")
+  largest <- read_octron(path, method = "largest")
+
+  expect_equal(weighted$x, largest$x)
+  expect_equal(weighted$y, largest$y)
+  expect_equal(weighted$area, largest$area)
+})
+
+test_that("read_octron(method = 'segments') still works on scalar-only files", {
+  path <- test_path("data/octron", "octron_sample.csv")
+  result <- read_octron(path, method = "segments")
+
+  expect_true("segment" %in% names(result))
+  # Every row from a scalar file gets segment = 1
+  expect_equal(unique(as.character(result$segment)), "1")
+})

--- a/tests/testthat/test-read_octron.R
+++ b/tests/testthat/test-read_octron.R
@@ -308,3 +308,84 @@ test_that("read_octron(method = 'segments') still works on scalar-only files", {
   # Every row from a scalar file gets segment = 1
   expect_equal(unique(as.character(result$segment)), "1")
 })
+
+# --- Edge cases for the internal tuple resolvers ---
+
+test_that("parse_octron_column passes numeric columns through as a list", {
+  expect_equal(parse_octron_column(c(1, 2, 3)), list(1, 2, 3))
+})
+
+test_that("parse_octron_column converts NA character entries to NA_real_", {
+  result <- parse_octron_column(c("(1.0, 2.0)", NA_character_, "3.0"))
+  expect_equal(result[[1]], c(1, 2))
+  expect_true(is.na(result[[2]]))
+  expect_equal(result[[3]], 3)
+})
+
+test_that("resolve_largest returns NA when every segment value is NA", {
+  out <- resolve_largest(
+    list(c(NA_real_, NA_real_)),
+    list(c(1, 2))
+  )
+  expect_true(is.na(out))
+})
+
+test_that("resolve_largest defaults to the first segment when all areas are NA", {
+  # which.max() returns integer(0) on an all-NA vector — code falls back to idx 1.
+  out <- resolve_largest(
+    list(c(10, 20)),
+    list(c(NA_real_, NA_real_))
+  )
+  expect_equal(out, 10)
+})
+
+test_that("resolve_weighted returns NA when every segment value is NA", {
+  out <- resolve_weighted(
+    list(c(NA_real_, NA_real_)),
+    list(c(1, 2))
+  )
+  expect_true(is.na(out))
+})
+
+test_that("resolve_weighted falls back to arithmetic mean when areas sum to 0", {
+  out <- resolve_weighted(list(c(10, 20)), list(c(0, 0)))
+  expect_equal(out, 15)
+})
+
+test_that("read_octron resolves tuples when no `area` column is present", {
+  # Bytetrack-flavoured Octron exports omit the `area` column; the
+  # resolver falls back to equal weights (arithmetic mean for `weighted`,
+  # first segment for `largest`).
+  path <- tempfile(fileext = ".csv")
+  on.exit(unlink(path), add = TRUE)
+  writeLines(
+    c(
+      "video_name: test.mp4",
+      "frame_count: 2",
+      "frame_count_analyzed: 2",
+      "video_height: 1000",
+      "video_width: 1000",
+      "created_at: 2025-10-04 09:06:31",
+      "frame_counter,frame_idx,track_id,label,pos_x,pos_y,bbox_area,bbox_aspect_ratio,bbox_x_min,bbox_x_max,bbox_y_min,bbox_y_max,confidence",
+      "0,0,1,worm,100.0,200.0,1000.0,0.5,80.0,120.0,180.0,220.0,0.9",
+      paste0(
+        "1,1,1,worm,",
+        '"(150.0, 250.0)","(300.0, 350.0)",',
+        "2000.0,0.6,140.0,260.0,290.0,360.0,0.85"
+      )
+    ),
+    path
+  )
+
+  weighted <- read_octron(path, method = "weighted")
+  largest <- read_octron(path, method = "largest")
+
+  expect_equal(nrow(weighted), 2)
+  multi_w <- weighted[weighted$time == 1, ]
+  expect_equal(multi_w$x, mean(c(150, 250)))
+  expect_equal(multi_w$y, 1000 - mean(c(300, 350)))
+
+  multi_l <- largest[largest$time == 1, ]
+  expect_equal(multi_l$x, 150)
+  expect_equal(multi_l$y, 1000 - 300)
+})


### PR DESCRIPTION
## Summary

Closes #67. See also OCTRON-tracking/OCTRON-GUI#63 and roaldarbol/OCTRON-GUI#17 for upstream context.

Newer Octron exports emit per-segment columns as tuple-strings like \`\"(120.5, 85.3)\"\` when YOLO detects multiple disconnected mask segments belonging to the same track in one frame. Previously \`read_octron()\` let \`vroom\` silently turn the affected columns into character, which broke every downstream numeric step.

\`read_octron(method = c(\"weighted\", \"largest\", \"segments\"))\` resolves those rows:

| method | what it does | row count change |
|---|---|---|
| \`weighted\` (default) | area-weighted mean of position + shape props; \`area\` → sum of segment areas; \`orientation\` falls back to \`largest\` (circular quantity) | none |
| \`largest\` | pick values from the largest segment per row | none |
| \`segments\` | explode each multi-segment row into one row per segment, with a new \`segment\` identity variable | rows ↑ |

Scalar-only files (older Octron exports, or runs where no frame ever produced multiple segments) behave identically to before regardless of \`method\`. The strategy mirrors the upstream \`octron export\`'s \`weighted\`/\`largest\` resolvers; \`raw\` is intentionally not exposed because tuple-string columns don't fit aniframe's numeric expectations.

## Test plan

New tests in \`tests/testthat/test-read_octron.R\`:

- [ ] synthetic 3-row CSV with one multi-segment row (areas \`(800, 200)\`)
  - [ ] \`weighted\`: x = 0.8·150 + 0.2·200 = 160; y reflected; area = 1000; orientation = -0.3 (largest)
  - [ ] \`largest\`: all values from segment with area 800
  - [ ] \`segments\`: 4 output rows, \`segment\` factor column present, original per-segment values preserved
- [ ] default method is \`weighted\`
- [ ] unknown \`method\` errors
- [ ] scalar-only file: \`weighted\` / \`largest\` / \`segments\` all produce same numeric output (segments adds \`segment = 1\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)