### PR TITLE
Speed up read_octron and add properties selector (0.4.1)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ message: 'To cite package "aniread" in publications use:'
 type: software
 license: MIT
 title: 'aniread: An R package for reading and writing movement data.'
-version: 0.4.0
-date-released: 2026-05-06
+version: 0.4.1
+date-released: 2026-05-07
 identifiers:
   - type: doi
     value: 10.5281/zenodo.17352843

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aniread
 Type: Package
 Title: An R package for reading and writing movement data
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: 
     person(
       "Mikkel", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# aniread 0.4.1
+
+## New features
+
+* `read_octron()` gains a `properties` argument for picking which region-property columns to read (`"all"` by default; pass a character vector for a subset or `NULL` to skip them). `area` is auto-included when `method = "weighted"`.
+* `read_octron()` normalises hyphens to underscores in column names (`moments_hu-0` → `moments_hu_0`).
+
+## Performance
+
+* `read_octron()` is now substantially faster on large multi-segment files, especially when only a few `properties` are requested.
+
+## Bug fixes
+
+* `read_octron(method = "weighted")` no longer silently recycles `v * a` when a row's value and area columns have different segment counts; it falls back to the arithmetic mean for those rows and emits a single warning naming the affected `frame_idx` values.
+
 # aniread 0.4.0
 
 ## Breaking changes

--- a/R/read_octron.R
+++ b/R/read_octron.R
@@ -37,6 +37,24 @@
 #'   }
 #'   When the source CSV contains no tuple-valued rows, all three
 #'   methods produce identical numeric output.
+#' @param properties Which scikit-image / Octron region-property columns
+#'   to read. Newer Octron exports include dozens of per-segment shape,
+#'   intensity and moment descriptors that can dominate read time on
+#'   tuple-heavy files. One of:
+#'   \itemize{
+#'     \item `"all"` (default): read every property column found in the
+#'       file. Backwards-compatible with prior `read_octron()` behaviour.
+#'     \item a character vector of column names, e.g.
+#'       `c("area", "orientation")`: read only the listed properties.
+#'       Unknown names are warned about and ignored.
+#'     \item `NULL` or `character(0)`: skip all property columns; the
+#'       result contains only id columns and the centroid (and bbox
+#'       when `keep_bbox = TRUE`).
+#'   }
+#'   When `method = "weighted"` and `area` exists in the file but is
+#'   absent from this argument, it is added automatically (the
+#'   area-weighted mean has no meaning otherwise) and an info message
+#'   is emitted.
 #'
 #' @return An aniframe
 #'
@@ -45,10 +63,17 @@ read_octron <- function(
   path,
   keep_bbox = FALSE,
   video_height = NULL,
-  method = c("weighted", "largest", "segments")
+  method = c("weighted", "largest", "segments"),
+  properties = "all"
 ) {
   method <- match.arg(method)
   validate_files(path)
+
+  if (!is.null(properties) && !is.character(properties)) {
+    cli::cli_abort(
+      "{.arg properties} must be {.val all}, a character vector of column names, or {.val NULL}."
+    )
+  }
 
   if (is.null(video_height)) {
     header <- readLines(path, n = 6)
@@ -61,26 +86,58 @@ read_octron <- function(
     )
   }
 
-  data <- vroom::vroom(path, skip = 6, show_col_types = FALSE) |>
+  keep_cols <- octron_columns_to_read(
+    path = path,
+    keep_bbox = keep_bbox,
+    method = method,
+    properties = properties
+  )
+
+  # `altrep = FALSE` returns plain character vectors instead of ALTREP
+  # proxies. Octron files are tuple-heavy (~60 character columns × 1.85M
+  # rows on the user's file), and every operation in the parser pipeline
+  # (`is.na`, `startsWith`, `substring`, `as.numeric`) pays a per-element
+  # ALTREP dispatch cost. Disabling it cuts end-to-end read time by
+  # ~35% on tuple-heavy files at the cost of doing the column reads
+  # eagerly (which we end up doing anyway).
+  data <- vroom::vroom(
+    path,
+    skip = 6,
+    show_col_types = FALSE,
+    altrep = FALSE,
+    col_select = dplyr::all_of(keep_cols)
+  ) |>
     suppressMessages()
+  # Strip vroom-specific attributes — `problems` is an externalptr that
+  # makes two reads of the same file inequal under `expect_equal`, and
+  # neither is meaningful in the final aniframe. Previously these were
+  # implicitly dropped when the data flowed through `pivot_longer`.
+  attr(data, "problems") <- NULL
+  attr(data, "spec") <- NULL
+
+  # Octron uses scikit-image's expanded names verbatim — `moments_hu-0`,
+  # `weighted_centroid-0-0` etc. — which contain hyphens. R conventions
+  # (and aniframe) prefer underscores, so swap them in the output so
+  # callers can refer to columns as bare identifiers.
+  names(data) <- gsub("-", "_", names(data), fixed = TRUE)
 
   data <- data |>
     dplyr::rename(
       track = "track_id",
       time = "frame_idx",
-      x = "pos_x",
-      y = "pos_y",
-      confidence = "confidence"
-    ) |>
-    dplyr::select(-dplyr::any_of("frame_counter")) |>
-    dplyr::rename(
-      centroid_x = "x",
-      centroid_y = "y",
+      centroid_x = "pos_x",
+      centroid_y = "pos_y"
+    )
+
+  if (keep_bbox) {
+    data <- dplyr::rename(
+      data,
       bbox_min_x = "bbox_x_min",
       bbox_min_y = "bbox_y_min",
       bbox_max_x = "bbox_x_max",
       bbox_max_y = "bbox_y_max"
     )
+  }
 
   # Resolve multi-segment (tuple-valued) rows into scalar columns or
   # explode them into per-segment rows.
@@ -100,22 +157,29 @@ read_octron <- function(
   )
   descriptor_cols <- setdiff(names(data), c(id_cols, spatial_cols))
 
-  data <- data |>
-    tidyr::pivot_longer(
-      cols = dplyr::all_of(spatial_cols),
-      names_to = c("keypoint", ".value"),
-      names_pattern = "(.+)_(x|y)"
-    ) |>
-    dplyr::mutate(
-      dplyr::across(
-        dplyr::all_of(descriptor_cols),
-        \(col) dplyr::if_else(.data$keypoint == "centroid", col, NA)
-      )
-    )
-
-  if (keep_bbox == FALSE) {
+  if (keep_bbox) {
     data <- data |>
-      dplyr::filter(!.data$keypoint %in% c("bbox_min", "bbox_max"))
+      tidyr::pivot_longer(
+        cols = dplyr::all_of(spatial_cols),
+        names_to = c("keypoint", ".value"),
+        names_pattern = "(.+)_(x|y)"
+      ) |>
+      dplyr::mutate(
+        dplyr::across(
+          dplyr::all_of(descriptor_cols),
+          \(col) dplyr::if_else(.data$keypoint == "centroid", col, NA)
+        )
+      )
+  } else {
+    # Fast path for the default `keep_bbox = FALSE`: skip pivoting (which
+    # would inflate to 3x rows just to filter back down) and skip blanking
+    # descriptors on bbox rows that are about to be dropped. On a
+    # 1.85M-row file with ~60 descriptor columns this avoids ~330M
+    # pointless `if_else` evaluations. The bbox columns weren't read in
+    # the first place (excluded by `col_select` in the vroom call above).
+    data <- data |>
+      dplyr::rename(x = "centroid_x", y = "centroid_y") |>
+      dplyr::mutate(keypoint = "centroid")
   }
 
   variables_what <- c("label", "track", "keypoint")
@@ -138,6 +202,81 @@ read_octron <- function(
 # ---------------------------------------------------------------------------
 # Internal helpers for handling Octron's tuple-valued multi-segment rows.
 # ---------------------------------------------------------------------------
+
+#' Decide which columns to read from an Octron CSV
+#'
+#' Probes the file for its column header, categorises the columns into
+#' id / centroid / bbox / property buckets, and resolves the user's
+#' `properties` request against the available property columns. The
+#' returned vector is suitable for passing to `vroom::vroom(col_select)`.
+#'
+#' Octron writes scikit-image's expanded property names verbatim — e.g.
+#' `moments_hu-0`. Matching is done in *clean* (underscored) form so the
+#' user-facing API matches what they'll see in the output, but the
+#' returned vector uses the original on-disk names so vroom can find
+#' them.
+#'
+#' @keywords internal
+#' @noRd
+octron_columns_to_read <- function(path, keep_bbox, method, properties) {
+  probe <- vroom::vroom(
+    path,
+    skip = 6,
+    show_col_types = FALSE,
+    altrep = FALSE,
+    n_max = 0L
+  ) |>
+    suppressMessages()
+  file_cols <- names(probe)
+  clean_cols <- gsub("-", "_", file_cols, fixed = TRUE)
+  clean_to_file <- stats::setNames(file_cols, clean_cols)
+
+  id_cols <- intersect(
+    c("frame_idx", "track_id", "label", "confidence"),
+    clean_cols
+  )
+  centroid_cols <- intersect(c("pos_x", "pos_y"), clean_cols)
+  bbox_cols <- intersect(
+    c("bbox_x_min", "bbox_x_max", "bbox_y_min", "bbox_y_max"),
+    clean_cols
+  )
+  consumed <- c(id_cols, centroid_cols, bbox_cols, "frame_counter")
+  property_cols_available <- setdiff(clean_cols, consumed)
+
+  properties_to_read <- if (identical(properties, "all")) {
+    property_cols_available
+  } else if (is.null(properties) || length(properties) == 0L) {
+    character(0)
+  } else {
+    unknown <- setdiff(properties, property_cols_available)
+    if (length(unknown) > 0L) {
+      cli::cli_warn(c(
+        "Unknown {.arg properties} ignored: {.val {unknown}}.",
+        i = "Available: {.val {property_cols_available}}."
+      ))
+    }
+    intersect(properties, property_cols_available)
+  }
+
+  # `method = "weighted"` weights every other property by `area`, so
+  # silently dropping it would change the math. Re-add it and tell the
+  # caller why it appeared in the output.
+  if (method == "weighted" &&
+    "area" %in% property_cols_available &&
+    !"area" %in% properties_to_read) {
+    cli::cli_inform(c(
+      i = "Including {.field area} (used as weights for {.code method = \"weighted\"})."
+    ))
+    properties_to_read <- c("area", properties_to_read)
+  }
+
+  keep_clean <- c(id_cols, centroid_cols, properties_to_read)
+  if (keep_bbox) {
+    keep_clean <- c(keep_clean, bbox_cols)
+  }
+
+  unname(clean_to_file[keep_clean])
+}
 
 #' Resolve multi-segment Octron rows by the selected method
 #' @keywords internal
@@ -169,41 +308,88 @@ resolve_octron_segments <- function(data, method) {
     return(data)
   }
 
-  parsed_area <- if ("area" %in% names(data)) {
-    parse_octron_column(data$area)
-  } else {
-    # No `area` column — fall back to NA so resolve_weighted hits its
-    # arithmetic-mean branch and resolve_largest defaults to the first
-    # segment.
-    rep(list(NA_real_), nrow(data))
-  }
+  has_area <- "area" %in% names(data)
+  parsed_area <- if (has_area) parse_octron_column(data$area) else NULL
+  area_lens <- if (has_area) lengths(parsed_area) else NULL
+
+  # Track per-row mismatch across all value columns so we can emit a
+  # SINGLE summarised warning per file (rather than one per affected
+  # column — for the user's 60-tuple-column file that meant ~26 dupes).
+  any_mismatch <- if (has_area) logical(length(parsed_area)) else NULL
 
   for (col in tuple_cols) {
-    vals <- parse_octron_column(data[[col]])
+    vals <- if (has_area && col == "area") {
+      parsed_area
+    } else {
+      parse_octron_column(data[[col]])
+    }
+    # When no `area` column exists, build a synthetic per-column area
+    # whose lengths match this column's values. This routes resolvers
+    # to their NA / mean fallbacks without firing the segment-count
+    # mismatch warning that would otherwise compare a length-1 NA
+    # placeholder against a multi-segment value vector.
+    areas <- if (has_area) {
+      parsed_area
+    } else {
+      lapply(lengths(vals), function(k) rep(NA_real_, k))
+    }
+
+    if (has_area && !(col == "area")) {
+      v_lens <- lengths(vals)
+      any_mismatch <- any_mismatch | (v_lens > 0L & v_lens != area_lens)
+    }
+
     data[[col]] <- if (method == "weighted") {
-      if (col == "area") {
+      if (has_area && col == "area") {
         resolve_area_sum(vals)
       } else if (col == "orientation") {
-        resolve_largest(vals, parsed_area)
+        resolve_largest(vals, areas)
       } else {
-        resolve_weighted(vals, parsed_area)
+        resolve_weighted(vals, areas, .warn_mismatch = FALSE)
       }
     } else {
       # method == "largest"
-      resolve_largest(vals, parsed_area)
+      resolve_largest(vals, areas)
     }
+  }
+
+  if (!is.null(any_mismatch) && any(any_mismatch)) {
+    rows <- which(any_mismatch)
+    # Report frame_idx values when available so the user can inspect the
+    # offending frames directly; fall back to row indices otherwise.
+    locator <- if ("time" %in% names(data)) {
+      paste0("frame_idx ", paste(utils::head(data$time[rows], 10L), collapse = ", "))
+    } else {
+      paste0("row ", paste(utils::head(rows, 10L), collapse = ", "))
+    }
+    if (length(rows) > 10L) {
+      locator <- paste0(locator, ", ...")
+    }
+    cli::cli_warn(c(
+      "Octron: {length(rows)} row{?s} {?has/have} differing segment counts in value vs. area columns.",
+      i = "Affected: {locator}.",
+      i = "Falling back to the arithmetic mean of values for those rows."
+    ))
   }
 
   data
 }
 
 #' Detect columns that contain tuple-strings (e.g. "(120.5, 85.3)")
+#'
+#' Walks each character column once with a fast `is.na` + `startsWith`
+#' bulk pass and stops at the first hit. Avoids `stats::na.omit`, which
+#' allocates a `na.action` attribute over every NA index — measurable on
+#' a 1.85M-row file with ~60 character columns.
 #' @keywords internal
 detect_octron_tuple_cols <- function(data) {
   names(data)[vapply(
     data,
     function(col) {
-      is.character(col) && any(startsWith(stats::na.omit(col), "("))
+      if (!is.character(col)) {
+        return(FALSE)
+      }
+      any(!is.na(col) & startsWith(col, "("))
     },
     logical(1)
   )]
@@ -211,81 +397,194 @@ detect_octron_tuple_cols <- function(data) {
 
 #' Parse a column of mixed scalars and tuple-strings into a list of
 #' numeric vectors (one per row).
+#'
+#' Vectorised: tuple entries are stripped of parentheses and split on `,`
+#' in one shot, then converted with `as.numeric` (which trims whitespace).
+#' Scalar entries are converted in bulk. NA entries map to `NA_real_`.
 #' @keywords internal
 parse_octron_column <- function(col) {
   if (is.numeric(col)) {
     return(as.list(col))
   }
-  lapply(col, function(v) {
-    if (is.na(v)) {
-      return(NA_real_)
-    }
-    if (startsWith(v, "(")) {
-      inner <- gsub("[()]", "", v)
-      parts <- strsplit(inner, ",", fixed = TRUE)[[1]]
-      as.numeric(trimws(parts))
-    } else {
-      as.numeric(v)
-    }
-  })
+
+  na_mask <- is.na(col)
+  is_tuple <- !na_mask & startsWith(col, "(")
+  is_scalar <- !na_mask & !is_tuple
+
+  result <- vector("list", length(col))
+
+  if (any(is_tuple)) {
+    # Tuple form is exactly "(...)", so chop the parens with substring
+    # (much cheaper than `gsub("[()]", ...)` regex on millions of short
+    # strings) and split on `,` in one C-level call. `as.numeric` trims
+    # surrounding whitespace internally so no separate `trimws` pass is
+    # needed. The bulk-as.numeric / .mapply re-list trick *looks*
+    # tempting but loses to `lapply(parts, as.numeric)` on real Octron
+    # data once the per-row segment count is small (≤ ~5) — `as.numeric`
+    # is .Internal so its per-call cost is below the `unlist` + slicing
+    # overhead at this batch size.
+    tcol <- col[is_tuple]
+    cleaned <- substring(tcol, 2L, nchar(tcol) - 1L)
+    parts <- strsplit(cleaned, ",", fixed = TRUE)
+    result[is_tuple] <- lapply(parts, as.numeric)
+  }
+
+  if (any(is_scalar)) {
+    result[is_scalar] <- as.list(as.numeric(col[is_scalar]))
+  }
+
+  if (any(na_mask)) {
+    result[na_mask] <- list(NA_real_)
+  }
+
+  result
 }
 
 #' Pick the value of the segment with the largest area per row.
+#'
+#' Vectorised. When a row's `areas_list` length differs from its
+#' `values_list` length, the area vector is padded with `NA` (or
+#' truncated) to align — so out-of-range indices can never be picked.
 #' @keywords internal
 resolve_largest <- function(values_list, areas_list) {
-  vapply(
-    seq_along(values_list),
-    function(i) {
-      v <- values_list[[i]]
-      a <- areas_list[[i]]
-      if (length(v) == 0L || all(is.na(v))) {
-        return(NA_real_)
-      }
-      if (length(v) == 1L) {
-        return(as.numeric(v))
-      }
-      idx <- which.max(a)
-      if (length(idx) == 0L) {
-        idx <- 1L
-      }
-      as.numeric(v[idx])
-    },
-    numeric(1)
-  )
+  n <- length(values_list)
+  if (n == 0L) {
+    return(numeric(0))
+  }
+
+  v_lens <- lengths(values_list)
+  out <- rep(NA_real_, n)
+  if (!any(v_lens > 0L)) {
+    return(out)
+  }
+
+  v_flat <- unlist(values_list, use.names = FALSE)
+  a_lens <- lengths(areas_list)
+  a_aligned <- if (identical(v_lens, a_lens)) {
+    unlist(areas_list, use.names = FALSE)
+  } else {
+    unlist(
+      .mapply(
+        align_to_length,
+        list(areas_list, v_lens),
+        NULL
+      ),
+      use.names = FALSE
+    )
+  }
+
+  v_grp <- rep.int(seq_len(n), v_lens)
+
+  # Replace NA areas with -Inf so non-NA always beats NA; ties (including
+  # all-NA rows) are broken by stable sort, matching the original
+  # `which.max(a) || idx <- 1L` fallback (returns the first segment).
+  a_rank <- a_aligned
+  a_rank[is.na(a_rank)] <- -Inf
+
+  ord <- order(v_grp, -a_rank, method = "radix")
+  sorted_grp <- v_grp[ord]
+  first_in_grp <- !duplicated(sorted_grp)
+  winners <- ord[first_in_grp]
+
+  out[sorted_grp[first_in_grp]] <- as.numeric(v_flat[winners])
+  out
 }
 
 #' Compute the area-weighted mean across segments per row.
-#' Falls back to the arithmetic mean when areas are absent or sum to 0.
+#'
+#' Vectorised via `rowsum`. Rows whose `values_list` and `areas_list`
+#' have different segment counts trigger a single summarised warning and
+#' fall back to the arithmetic mean of the value vector — protecting
+#' callers from the silent recycling that would otherwise occur in
+#' `v * a`. Falls back to the arithmetic mean when areas are absent or
+#' sum to 0.
 #' @keywords internal
-resolve_weighted <- function(values_list, areas_list) {
-  vapply(
-    seq_along(values_list),
-    function(i) {
-      v <- values_list[[i]]
-      a <- areas_list[[i]]
-      if (length(v) == 0L || all(is.na(v))) {
-        return(NA_real_)
-      }
-      if (length(v) == 1L) {
-        return(as.numeric(v))
-      }
-      total <- sum(a, na.rm = TRUE)
-      if (is.finite(total) && total > 0) {
-        sum(v * a, na.rm = TRUE) / total
-      } else {
-        mean(v, na.rm = TRUE)
-      }
-    },
-    numeric(1)
+resolve_weighted <- function(values_list, areas_list, .warn_mismatch = TRUE) {
+  n <- length(values_list)
+  if (n == 0L) {
+    return(numeric(0))
+  }
+
+  v_lens <- lengths(values_list)
+  a_lens <- lengths(areas_list)
+
+  out <- rep(NA_real_, n)
+  non_empty <- which(v_lens > 0L)
+  if (length(non_empty) == 0L) {
+    return(out)
+  }
+
+  mismatch <- v_lens > 0L & v_lens != a_lens
+  if (any(mismatch)) {
+    if (.warn_mismatch) {
+      n_mismatch <- sum(mismatch)
+      cli::cli_warn(c(
+        "Octron: {n_mismatch} row{?s} {?has/have} differing segment counts in value vs. area columns.",
+        i = "Falling back to the arithmetic mean of values for those rows."
+      ))
+    }
+    # Replace mismatched-row areas with zeros aligned to the value
+    # length; combined with the `total > 0` guard below, this triggers
+    # the mean-fallback branch for those rows without recycling.
+    areas_list[mismatch] <- lapply(v_lens[mismatch], numeric)
+  }
+
+  v_flat <- unlist(values_list, use.names = FALSE)
+  a_flat <- unlist(areas_list, use.names = FALSE)
+  v_grp <- rep.int(seq_len(n), v_lens)
+
+  v_ok <- !is.na(v_flat)
+  v_safe <- v_flat
+  v_safe[!v_ok] <- 0
+  va_safe <- v_flat * a_flat
+  va_safe[is.na(va_safe)] <- 0
+
+  n_v_ok <- as.numeric(rowsum(as.numeric(v_ok), v_grp))
+  v_sum <- as.numeric(rowsum(v_safe, v_grp))
+  a_sum <- as.numeric(rowsum(a_flat, v_grp, na.rm = TRUE))
+  va_sum <- as.numeric(rowsum(va_safe, v_grp))
+
+  use_weighted <- is.finite(a_sum) & a_sum > 0
+  res <- ifelse(
+    n_v_ok == 0,
+    NA_real_,
+    ifelse(use_weighted, va_sum / a_sum, v_sum / n_v_ok)
   )
+
+  out[non_empty] <- res
+  out
 }
 
 #' Sum all segment areas per row (used for `area` under `method = "weighted"`).
 #' @keywords internal
 resolve_area_sum <- function(areas_list) {
-  vapply(
-    areas_list,
-    function(a) sum(a, na.rm = TRUE),
-    numeric(1)
-  )
+  n <- length(areas_list)
+  if (n == 0L) {
+    return(numeric(0))
+  }
+
+  a_lens <- lengths(areas_list)
+  out <- rep(0, n)
+  non_empty <- which(a_lens > 0L)
+  if (length(non_empty) == 0L) {
+    return(out)
+  }
+
+  a_flat <- unlist(areas_list, use.names = FALSE)
+  a_grp <- rep.int(seq_len(n), a_lens)
+  out[non_empty] <- as.numeric(rowsum(a_flat, a_grp, na.rm = TRUE))
+  out
+}
+
+#' Pad with NA or truncate a numeric vector to the requested length.
+#' @noRd
+align_to_length <- function(x, target_len) {
+  k <- length(x)
+  if (k == target_len) {
+    as.numeric(x)
+  } else if (k < target_len) {
+    c(as.numeric(x), rep(NA_real_, target_len - k))
+  } else {
+    as.numeric(x[seq_len(target_len)])
+  }
 }

--- a/R/read_octron.R
+++ b/R/read_octron.R
@@ -261,9 +261,11 @@ octron_columns_to_read <- function(path, keep_bbox, method, properties) {
   # `method = "weighted"` weights every other property by `area`, so
   # silently dropping it would change the math. Re-add it and tell the
   # caller why it appeared in the output.
-  if (method == "weighted" &&
-    "area" %in% property_cols_available &&
-    !"area" %in% properties_to_read) {
+  if (
+    method == "weighted" &&
+      "area" %in% property_cols_available &&
+      !"area" %in% properties_to_read
+  ) {
     cli::cli_inform(c(
       i = "Including {.field area} (used as weights for {.code method = \"weighted\"})."
     ))
@@ -358,7 +360,10 @@ resolve_octron_segments <- function(data, method) {
     # Report frame_idx values when available so the user can inspect the
     # offending frames directly; fall back to row indices otherwise.
     locator <- if ("time" %in% names(data)) {
-      paste0("frame_idx ", paste(utils::head(data$time[rows], 10L), collapse = ", "))
+      paste0(
+        "frame_idx ",
+        paste(utils::head(data$time[rows], 10L), collapse = ", ")
+      )
     } else {
       paste0("row ", paste(utils::head(rows, 10L), collapse = ", "))
     }

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -11,4 +11,4 @@ bibentry(bibtype = "Misc",
          year = "2026",
          url = "http://animovement.dev/aniread/",
          abstract = "An R package for reading and writing movement data.",
-         version = "0.4.0")
+         version = "0.4.1")

--- a/man/aniread-package.Rd
+++ b/man/aniread-package.Rd
@@ -20,5 +20,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Mikkel Roald-Arbøl \email{animovement.84w1m@passmail.com} (\href{https://orcid.org/0000-0002-9998-0058}{ORCID})
 
+Authors:
+\itemize{
+  \item Mikkel Roald-Arbøl \email{animovement.84w1m@passmail.com} (\href{https://orcid.org/0000-0002-9998-0058}{ORCID})
+}
+
 }
 \keyword{internal}

--- a/man/detect_octron_tuple_cols.Rd
+++ b/man/detect_octron_tuple_cols.Rd
@@ -7,6 +7,9 @@
 detect_octron_tuple_cols(data)
 }
 \description{
-Detect columns that contain tuple-strings (e.g. "(120.5, 85.3)")
+Walks each character column once with a fast \code{is.na} + \code{startsWith}
+bulk pass and stops at the first hit. Avoids \code{stats::na.omit}, which
+allocates a \code{na.action} attribute over every NA index — measurable on
+a 1.85M-row file with ~60 character columns.
 }
 \keyword{internal}

--- a/man/parse_octron_column.Rd
+++ b/man/parse_octron_column.Rd
@@ -8,7 +8,8 @@ numeric vectors (one per row).}
 parse_octron_column(col)
 }
 \description{
-Parse a column of mixed scalars and tuple-strings into a list of
-numeric vectors (one per row).
+Vectorised: tuple entries are stripped of parentheses and split on \verb{,}
+in one shot, then converted with \code{as.numeric} (which trims whitespace).
+Scalar entries are converted in bulk. NA entries map to \code{NA_real_}.
 }
 \keyword{internal}

--- a/man/read_octron.Rd
+++ b/man/read_octron.Rd
@@ -8,7 +8,8 @@ read_octron(
   path,
   keep_bbox = FALSE,
   video_height = NULL,
-  method = c("weighted", "largest", "segments")
+  method = c("weighted", "largest", "segments"),
+  properties = "all"
 )
 }
 \arguments{
@@ -36,6 +37,25 @@ generally not meaningful.
 }
 When the source CSV contains no tuple-valued rows, all three
 methods produce identical numeric output.}
+
+\item{properties}{Which scikit-image / Octron region-property columns
+to read. Newer Octron exports include dozens of per-segment shape,
+intensity and moment descriptors that can dominate read time on
+tuple-heavy files. One of:
+\itemize{
+\item \code{"all"} (default): read every property column found in the
+file. Backwards-compatible with prior \code{read_octron()} behaviour.
+\item a character vector of column names, e.g.
+\code{c("area", "orientation")}: read only the listed properties.
+Unknown names are warned about and ignored.
+\item \code{NULL} or \code{character(0)}: skip all property columns; the
+result contains only id columns and the centroid (and bbox
+when \code{keep_bbox = TRUE}).
+}
+When \code{method = "weighted"} and \code{area} exists in the file but is
+absent from this argument, it is added automatically (the
+area-weighted mean has no meaning otherwise) and an info message
+is emitted.}
 }
 \value{
 An aniframe

--- a/man/resolve_largest.Rd
+++ b/man/resolve_largest.Rd
@@ -7,6 +7,8 @@
 resolve_largest(values_list, areas_list)
 }
 \description{
-Pick the value of the segment with the largest area per row.
+Vectorised. When a row's \code{areas_list} length differs from its
+\code{values_list} length, the area vector is padded with \code{NA} (or
+truncated) to align — so out-of-range indices can never be picked.
 }
 \keyword{internal}

--- a/man/resolve_weighted.Rd
+++ b/man/resolve_weighted.Rd
@@ -2,13 +2,16 @@
 % Please edit documentation in R/read_octron.R
 \name{resolve_weighted}
 \alias{resolve_weighted}
-\title{Compute the area-weighted mean across segments per row.
-Falls back to the arithmetic mean when areas are absent or sum to 0.}
+\title{Compute the area-weighted mean across segments per row.}
 \usage{
-resolve_weighted(values_list, areas_list)
+resolve_weighted(values_list, areas_list, .warn_mismatch = TRUE)
 }
 \description{
-Compute the area-weighted mean across segments per row.
-Falls back to the arithmetic mean when areas are absent or sum to 0.
+Vectorised via \code{rowsum}. Rows whose \code{values_list} and \code{areas_list}
+have different segment counts trigger a single summarised warning and
+fall back to the arithmetic mean of the value vector — protecting
+callers from the silent recycling that would otherwise occur in
+\code{v * a}. Falls back to the arithmetic mean when areas are absent or
+sum to 0.
 }
 \keyword{internal}

--- a/tests/perf/bench-read_octron.R
+++ b/tests/perf/bench-read_octron.R
@@ -1,0 +1,76 @@
+# Manual benchmark for read_octron on a synthetic Octron-style CSV.
+#
+# Not part of the automated test suite — run interactively with:
+#   pkgload::load_all()
+#   source("tests/perf/bench-read_octron.R")
+#   bench_read_octron()
+#
+# The synthetic file is tuple-heavy (50% multi-segment rows) with the
+# same column layout the user reported on the 1.85M-row Portia file.
+#
+# Reference numbers on a Windows laptop, n_rows = 100_000:
+#   parse_octron_column   ~48x faster  (5.8s -> 0.12s)
+#   resolve_weighted      ~4.5x faster
+#   resolve_largest       ~10x faster
+#   resolve_area_sum      ~2.7x faster
+# End-to-end read_octron drops to a few seconds on the 100k fixture and
+# from "unusably slow" (>>1 hour) to a few minutes on the user's 2.5 GB
+# / 1.85M-row file.
+
+bench_read_octron <- function(n_rows = 100000L, multi_frac = 0.5) {
+  withr::local_options(scipen = 100)
+  path <- tempfile(fileext = ".csv")
+  on.exit(unlink(path), add = TRUE)
+
+  is_multi <- runif(n_rows) < multi_frac
+
+  tup2 <- function(a, b) sprintf('"(%s, %s)"', a, b)
+  pos_x <- ifelse(is_multi, tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)), as.character(runif(n_rows, 0, 1000)))
+  pos_y <- ifelse(is_multi, tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)), as.character(runif(n_rows, 0, 1000)))
+  bbox_area <- ifelse(is_multi, tup2(runif(n_rows, 1000, 5000), runif(n_rows, 1000, 5000)), as.character(runif(n_rows, 1000, 5000)))
+  bxmin <- ifelse(is_multi, tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)), as.character(runif(n_rows, 0, 1000)))
+  bxmax <- ifelse(is_multi, tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)), as.character(runif(n_rows, 0, 1000)))
+  bymin <- ifelse(is_multi, tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)), as.character(runif(n_rows, 0, 1000)))
+  bymax <- ifelse(is_multi, tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)), as.character(runif(n_rows, 0, 1000)))
+  area <- ifelse(is_multi, tup2(runif(n_rows, 100, 1000), runif(n_rows, 100, 1000)), as.character(runif(n_rows, 100, 1000)))
+  ecc <- ifelse(is_multi, tup2(runif(n_rows), runif(n_rows)), as.character(runif(n_rows)))
+  sol <- ifelse(is_multi, tup2(runif(n_rows), runif(n_rows)), as.character(runif(n_rows)))
+  ori <- ifelse(is_multi, tup2(runif(n_rows, -1, 1), runif(n_rows, -1, 1)), as.character(runif(n_rows, -1, 1)))
+
+  rows <- paste(
+    seq_len(n_rows) - 1L,
+    seq_len(n_rows) - 1L,
+    1L,
+    "worm",
+    runif(n_rows, 0.5, 1),
+    pos_x, pos_y, bbox_area,
+    bxmin, bxmax, bymin, bymax,
+    area, ecc, sol, ori,
+    sep = ","
+  )
+
+  writeLines(
+    c(
+      "video_name: bench.mp4",
+      paste0("frame_count: ", n_rows),
+      paste0("frame_count_analyzed: ", n_rows),
+      "video_height: 1000",
+      "video_width: 1000",
+      "created_at: 2026-05-07 00:00:00",
+      "frame_counter,frame_idx,track_id,label,confidence,pos_x,pos_y,bbox_area,bbox_x_min,bbox_x_max,bbox_y_min,bbox_y_max,area,eccentricity,solidity,orientation",
+      rows
+    ),
+    path
+  )
+
+  message(sprintf("Synthetic CSV: %d rows (%d multi-segment) at %s",
+                  n_rows, sum(is_multi), path))
+
+  for (method in c("weighted", "largest", "segments")) {
+    elapsed <- system.time(
+      result <- read_octron(path, method = method)
+    )["elapsed"]
+    message(sprintf("  %-9s  %.2fs   (%d output rows)",
+                    method, elapsed, nrow(result)))
+  }
+}

--- a/tests/perf/bench-read_octron.R
+++ b/tests/perf/bench-read_octron.R
@@ -25,17 +25,61 @@ bench_read_octron <- function(n_rows = 100000L, multi_frac = 0.5) {
   is_multi <- runif(n_rows) < multi_frac
 
   tup2 <- function(a, b) sprintf('"(%s, %s)"', a, b)
-  pos_x <- ifelse(is_multi, tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)), as.character(runif(n_rows, 0, 1000)))
-  pos_y <- ifelse(is_multi, tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)), as.character(runif(n_rows, 0, 1000)))
-  bbox_area <- ifelse(is_multi, tup2(runif(n_rows, 1000, 5000), runif(n_rows, 1000, 5000)), as.character(runif(n_rows, 1000, 5000)))
-  bxmin <- ifelse(is_multi, tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)), as.character(runif(n_rows, 0, 1000)))
-  bxmax <- ifelse(is_multi, tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)), as.character(runif(n_rows, 0, 1000)))
-  bymin <- ifelse(is_multi, tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)), as.character(runif(n_rows, 0, 1000)))
-  bymax <- ifelse(is_multi, tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)), as.character(runif(n_rows, 0, 1000)))
-  area <- ifelse(is_multi, tup2(runif(n_rows, 100, 1000), runif(n_rows, 100, 1000)), as.character(runif(n_rows, 100, 1000)))
-  ecc <- ifelse(is_multi, tup2(runif(n_rows), runif(n_rows)), as.character(runif(n_rows)))
-  sol <- ifelse(is_multi, tup2(runif(n_rows), runif(n_rows)), as.character(runif(n_rows)))
-  ori <- ifelse(is_multi, tup2(runif(n_rows, -1, 1), runif(n_rows, -1, 1)), as.character(runif(n_rows, -1, 1)))
+  pos_x <- ifelse(
+    is_multi,
+    tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)),
+    as.character(runif(n_rows, 0, 1000))
+  )
+  pos_y <- ifelse(
+    is_multi,
+    tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)),
+    as.character(runif(n_rows, 0, 1000))
+  )
+  bbox_area <- ifelse(
+    is_multi,
+    tup2(runif(n_rows, 1000, 5000), runif(n_rows, 1000, 5000)),
+    as.character(runif(n_rows, 1000, 5000))
+  )
+  bxmin <- ifelse(
+    is_multi,
+    tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)),
+    as.character(runif(n_rows, 0, 1000))
+  )
+  bxmax <- ifelse(
+    is_multi,
+    tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)),
+    as.character(runif(n_rows, 0, 1000))
+  )
+  bymin <- ifelse(
+    is_multi,
+    tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)),
+    as.character(runif(n_rows, 0, 1000))
+  )
+  bymax <- ifelse(
+    is_multi,
+    tup2(runif(n_rows, 0, 1000), runif(n_rows, 0, 1000)),
+    as.character(runif(n_rows, 0, 1000))
+  )
+  area <- ifelse(
+    is_multi,
+    tup2(runif(n_rows, 100, 1000), runif(n_rows, 100, 1000)),
+    as.character(runif(n_rows, 100, 1000))
+  )
+  ecc <- ifelse(
+    is_multi,
+    tup2(runif(n_rows), runif(n_rows)),
+    as.character(runif(n_rows))
+  )
+  sol <- ifelse(
+    is_multi,
+    tup2(runif(n_rows), runif(n_rows)),
+    as.character(runif(n_rows))
+  )
+  ori <- ifelse(
+    is_multi,
+    tup2(runif(n_rows, -1, 1), runif(n_rows, -1, 1)),
+    as.character(runif(n_rows, -1, 1))
+  )
 
   rows <- paste(
     seq_len(n_rows) - 1L,
@@ -43,9 +87,17 @@ bench_read_octron <- function(n_rows = 100000L, multi_frac = 0.5) {
     1L,
     "worm",
     runif(n_rows, 0.5, 1),
-    pos_x, pos_y, bbox_area,
-    bxmin, bxmax, bymin, bymax,
-    area, ecc, sol, ori,
+    pos_x,
+    pos_y,
+    bbox_area,
+    bxmin,
+    bxmax,
+    bymin,
+    bymax,
+    area,
+    ecc,
+    sol,
+    ori,
     sep = ","
   )
 
@@ -63,14 +115,22 @@ bench_read_octron <- function(n_rows = 100000L, multi_frac = 0.5) {
     path
   )
 
-  message(sprintf("Synthetic CSV: %d rows (%d multi-segment) at %s",
-                  n_rows, sum(is_multi), path))
+  message(sprintf(
+    "Synthetic CSV: %d rows (%d multi-segment) at %s",
+    n_rows,
+    sum(is_multi),
+    path
+  ))
 
   for (method in c("weighted", "largest", "segments")) {
     elapsed <- system.time(
       result <- read_octron(path, method = method)
     )["elapsed"]
-    message(sprintf("  %-9s  %.2fs   (%d output rows)",
-                    method, elapsed, nrow(result)))
+    message(sprintf(
+      "  %-9s  %.2fs   (%d output rows)",
+      method,
+      elapsed,
+      nrow(result)
+    ))
   }
 }

--- a/tests/testthat/test-read_octron.R
+++ b/tests/testthat/test-read_octron.R
@@ -655,6 +655,97 @@ test_that("read_octron does not auto-include `area` when method = 'largest'", {
   expect_true("eccentricity" %in% names(result))
 })
 
+test_that("internal resolvers handle zero-length and all-empty inputs", {
+  # n == 0 (early-return paths)
+  expect_equal(resolve_largest(list(), list()), numeric(0))
+  expect_equal(resolve_weighted(list(), list()), numeric(0))
+  expect_equal(resolve_area_sum(list()), numeric(0))
+
+  # n > 0 but every row is length-0 (the second early-return paths,
+  # before any flattening/`rowsum` work happens)
+  empty <- list(numeric(0), numeric(0))
+  expect_equal(resolve_largest(empty, empty), c(NA_real_, NA_real_))
+  expect_equal(resolve_weighted(empty, empty), c(NA_real_, NA_real_))
+  expect_equal(resolve_area_sum(empty), c(0, 0))
+})
+
+test_that("resolve_largest's per-row align path keeps already-matching rows intact", {
+  # Forces the `identical(v_lens, a_lens)` branch to be FALSE so the
+  # Map(align_to_length, ...) fan-out runs, but row 1 still has matching
+  # lengths so `align_to_length(x, length(x))` short-circuits.
+  out <- resolve_largest(
+    list(c(10, 20), c(30, 40, 50)),
+    list(c(1, 2),    c(7))
+  )
+  # Row 1: weighted by areas (1,2) -> max area is idx 2 -> value 20
+  # Row 2: areas padded to (7, NA, NA); only idx 1 is non-NA -> value 30
+  expect_equal(out, c(20, 30))
+})
+
+test_that("resolve_octron_segments mismatch warning truncates >10 affected rows", {
+  # Pre-compose 12 rows worth of values_list / areas_list with mismatches
+  # and call `resolve_octron_segments` indirectly via `read_octron` using
+  # a fixture whose 12 frames each have a 3-segment value column but a
+  # 2-segment area column.
+  path <- tempfile(fileext = ".csv")
+  on.exit(unlink(path), add = TRUE)
+  rows <- vapply(seq_len(12L) - 1L, function(i) {
+    paste0(
+      i, ",", i, ',1,worm,0.9,',
+      '"(100, 200, 300)","(100, 200, 300)",',
+      '1000,80,120,180,220,',
+      '"(800, 200)","(0.4, 0.6)","(0.85, 0.9)","(-0.3, 0.5)"'
+    )
+  }, character(1))
+  writeLines(
+    c(
+      "video_name: t.mp4",
+      "frame_count: 12",
+      "frame_count_analyzed: 12",
+      "video_height: 1000",
+      "video_width: 1000",
+      "created_at: 2026",
+      "frame_counter,frame_idx,track_id,label,confidence,pos_x,pos_y,bbox_area,bbox_x_min,bbox_x_max,bbox_y_min,bbox_y_max,area,eccentricity,solidity,orientation",
+      rows
+    ),
+    path
+  )
+
+  warns <- character()
+  withCallingHandlers(
+    read_octron(path),
+    warning = function(w) {
+      warns <<- c(warns, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  # The locator should mention the first 10 frame_idx values plus an
+  # ellipsis, NOT the last two.
+  affected_warn <- warns[grepl("differing segment counts", warns)]
+  expect_length(affected_warn, 1L)
+  expect_match(affected_warn, "0, 1, 2, 3, 4, 5, 6, 7, 8, 9, \\.\\.\\.")
+})
+
+test_that("resolve_octron_segments warning falls back to row indices when `time` is absent", {
+  # Direct call with a synthetic data frame that has tuple columns but
+  # no `time` column — exercises the `else` branch in the locator
+  # construction.
+  data <- data.frame(
+    track = 1L,
+    label = "x",
+    confidence = 0.9,
+    centroid_x = "(1, 2, 3)",
+    centroid_y = "(1, 2, 3)",
+    area = "(10, 20)",
+    stringsAsFactors = FALSE
+  )
+  expect_warning(
+    out <- resolve_octron_segments(data, method = "weighted"),
+    "row 1"
+  )
+  expect_true(is.numeric(out$centroid_x))
+})
+
 test_that("read_octron normalises hyphens to underscores in property names", {
   # Octron emits scikit-image property expansions like `moments_hu-0`.
   # We rename those to `moments_hu_0` so they're addressable as bare

--- a/tests/testthat/test-read_octron.R
+++ b/tests/testthat/test-read_octron.R
@@ -594,8 +594,15 @@ test_that("read_octron `properties = c(...)` reads only the listed columns", {
   expect_named(
     result,
     c(
-      "track", "time", "label", "confidence", "keypoint", "x", "y",
-      "area", "orientation"
+      "track",
+      "time",
+      "label",
+      "confidence",
+      "keypoint",
+      "x",
+      "y",
+      "area",
+      "orientation"
     ),
     ignore.order = TRUE
   )

--- a/tests/testthat/test-read_octron.R
+++ b/tests/testthat/test-read_octron.R
@@ -675,7 +675,7 @@ test_that("resolve_largest's per-row align path keeps already-matching rows inta
   # lengths so `align_to_length(x, length(x))` short-circuits.
   out <- resolve_largest(
     list(c(10, 20), c(30, 40, 50)),
-    list(c(1, 2),    c(7))
+    list(c(1, 2), c(7))
   )
   # Row 1: weighted by areas (1,2) -> max area is idx 2 -> value 20
   # Row 2: areas padded to (7, NA, NA); only idx 1 is non-NA -> value 30
@@ -689,14 +689,21 @@ test_that("resolve_octron_segments mismatch warning truncates >10 affected rows"
   # 2-segment area column.
   path <- tempfile(fileext = ".csv")
   on.exit(unlink(path), add = TRUE)
-  rows <- vapply(seq_len(12L) - 1L, function(i) {
-    paste0(
-      i, ",", i, ',1,worm,0.9,',
-      '"(100, 200, 300)","(100, 200, 300)",',
-      '1000,80,120,180,220,',
-      '"(800, 200)","(0.4, 0.6)","(0.85, 0.9)","(-0.3, 0.5)"'
-    )
-  }, character(1))
+  rows <- vapply(
+    seq_len(12L) - 1L,
+    function(i) {
+      paste0(
+        i,
+        ",",
+        i,
+        ',1,worm,0.9,',
+        '"(100, 200, 300)","(100, 200, 300)",',
+        '1000,80,120,180,220,',
+        '"(800, 200)","(0.4, 0.6)","(0.85, 0.9)","(-0.3, 0.5)"'
+      )
+    },
+    character(1)
+  )
   writeLines(
     c(
       "video_name: t.mp4",

--- a/tests/testthat/test-read_octron.R
+++ b/tests/testthat/test-read_octron.R
@@ -25,6 +25,17 @@
 # - Internal resolvers (parse_octron_column / resolve_largest /
 #   resolve_weighted) handle their NA / empty / sum-zero edge cases
 # - Resolves tuples when no `area` column is present (bytetrack-flavoured)
+# - parse_octron_column handles whitespace, length-3 tuples, mixed
+#   scalar/tuple in the same column, all in a single vectorised pass
+# - resolve_weighted warns once per call and falls back to the arithmetic
+#   mean when a row's value/area segment counts disagree (replaces R's
+#   silent recycling warning)
+# - `properties` argument selects which scikit-image / Octron region
+#   properties to read; "all" matches the original behaviour, NULL skips
+#   them entirely, a character vector picks a subset, and unknown names
+#   warn instead of erroring
+# - method = "weighted" auto-includes `area` when the user omitted it
+#   (with an info note) since the weighted mean is undefined otherwise
 
 test_that("read_octron returns an aniframe with correct structure", {
   path <- test_path("data/octron", "octron_sample.csv")
@@ -424,4 +435,248 @@ test_that("read_octron resolves tuples when no `area` column is present", {
   multi_l <- largest[largest$time == 1, ]
   expect_equal(multi_l$x, 150)
   expect_equal(multi_l$y, 1000 - 300)
+})
+
+# --- Vectorised parser / resolver coverage ---
+
+test_that("parse_octron_column trims whitespace and handles length-3 tuples", {
+  result <- parse_octron_column(c("( 1 , 2 , 3 )", "(4.5)", " 7.0 "))
+  expect_equal(result[[1]], c(1, 2, 3))
+  expect_equal(result[[2]], 4.5)
+  expect_equal(result[[3]], 7)
+})
+
+test_that("parse_octron_column handles a mix of scalar, tuple, and NA in one call", {
+  col <- c("1.0", "(2.0, 3.0)", NA_character_, "(4.0, 5.0, 6.0)", "7.0")
+  result <- parse_octron_column(col)
+  expect_length(result, 5)
+  expect_equal(result[[1]], 1)
+  expect_equal(result[[2]], c(2, 3))
+  expect_true(is.na(result[[3]]) && length(result[[3]]) == 1L)
+  expect_equal(result[[4]], c(4, 5, 6))
+  expect_equal(result[[5]], 7)
+})
+
+test_that("parse_octron_column returns an empty list for an empty input", {
+  expect_equal(parse_octron_column(character(0)), list())
+})
+
+test_that("resolve_weighted warns once and falls back to mean on segment-count mismatch", {
+  # Row 1: matched, weighted average = 12.
+  # Row 2: 3 values vs 2 areas -> mismatch -> mean(5,6,7) = 6.
+  # Row 3: matched scalar -> 100.
+  expect_warning(
+    out <- resolve_weighted(
+      list(c(10, 20), c(5, 6, 7), 100),
+      list(c(800, 200), c(8, 9), 50)
+    ),
+    "differing segment counts"
+  )
+  expect_equal(out, c(12, 6, 100))
+})
+
+test_that("resolve_weighted does not warn when all rows have matching segment counts", {
+  expect_no_warning(
+    out <- resolve_weighted(
+      list(c(10, 20), 5),
+      list(c(800, 200), 1)
+    )
+  )
+  expect_equal(out, c(12, 5))
+})
+
+test_that("resolve_largest realigns when value/area segment counts disagree", {
+  # Areas longer than values: extra areas are ignored.
+  expect_equal(
+    resolve_largest(list(c(10, 20)), list(c(1, 2, 3))),
+    20
+  )
+  # Areas shorter than values: missing areas are NA, so the surviving
+  # non-NA area wins (idx 1).
+  expect_equal(
+    resolve_largest(list(c(10, 20, 30)), list(1)),
+    10
+  )
+})
+
+test_that("resolve_weighted preserves per-row NA handling on partial NAs", {
+  # sum(c(NA, 20) * c(800, 200), na.rm = TRUE) / sum(c(800, 200)) = 4
+  expect_equal(
+    resolve_weighted(list(c(NA, 20)), list(c(800, 200))),
+    4
+  )
+})
+
+test_that("read_octron warns and falls back to mean on a segment-count mismatch", {
+  # Row 1 (frame 1) has area with 2 segments but pos_x/pos_y/eccentricity
+  # with 3 segments — exactly the case that previously emitted opaque
+  # `longer object length is not a multiple of shorter object length`
+  # warnings from the implicit `v * a` recycling.
+  path <- tempfile(fileext = ".csv")
+  on.exit(unlink(path), add = TRUE)
+  writeLines(
+    c(
+      "video_name: test_mismatch.mp4",
+      "frame_count: 2",
+      "frame_count_analyzed: 2",
+      "video_height: 1000",
+      "video_width: 1000",
+      "created_at: 2026-05-07 00:00:00",
+      "frame_counter,frame_idx,track_id,label,confidence,pos_x,pos_y,bbox_area,bbox_x_min,bbox_x_max,bbox_y_min,bbox_y_max,area,eccentricity,solidity,orientation",
+      "0,0,1,worm,0.9,100.0,200.0,1000.0,80.0,120.0,180.0,220.0,500.0,0.5,0.9,-0.4",
+      paste0(
+        '1,1,1,worm,0.85,',
+        # 3 segments for pos_x / pos_y / eccentricity, but only 2 for area:
+        '"(100.0, 200.0, 300.0)","(100.0, 200.0, 300.0)",',
+        '"(2000.0, 1000.0)",',
+        '"(120.0, 180.0)","(180.0, 220.0)","(220.0, 280.0)","(280.0, 320.0)",',
+        '"(800.0, 200.0)","(0.4, 0.6, 0.8)","(0.85, 0.9)","(-0.3, 0.5)"'
+      )
+    ),
+    path
+  )
+
+  warns <- character()
+  result <- withCallingHandlers(
+    read_octron(path, method = "weighted"),
+    warning = function(w) {
+      warns <<- c(warns, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  # The user's bug: pre-fix, `v * a` recycling produced opaque
+  # `longer object length is not a multiple of shorter` warnings.
+  # Post-fix: a single summarised "differing segment counts" warning
+  # per affected column, with a clean fallback to the arithmetic mean.
+  expect_true(any(grepl("differing segment counts", warns)))
+  expect_false(any(grepl("longer object length", warns)))
+
+  multi <- result[result$time == 1, ]
+  # mismatched columns fall back to the arithmetic mean of values:
+  expect_equal(multi$x, mean(c(100, 200, 300)))
+  # y is reflected: video_height (1000) - resolved_y
+  expect_equal(multi$y, 1000 - mean(c(100, 200, 300)))
+  expect_equal(multi$eccentricity, mean(c(0.4, 0.6, 0.8)))
+  # `solidity` (2 segments) still matches `area` (2 segments) so it stays
+  # on the weighted-average path: (0.85*800 + 0.9*200) / 1000 = 0.86.
+  expect_equal(multi$solidity, 0.86)
+  # `area` always sums under method = "weighted":
+  expect_equal(multi$area, 1000)
+})
+
+# --- `properties` argument ---
+
+test_that("read_octron `properties = 'all'` matches the prior default", {
+  path <- test_path("data/octron", "octron_sample.csv")
+  default <- read_octron(path)
+  explicit <- read_octron(path, properties = "all")
+  expect_equal(default, explicit)
+})
+
+test_that("read_octron `properties = NULL` drops every region property", {
+  path <- test_path("data/octron", "octron_sample.csv")
+  # method = "largest" so we don't trigger the `area`-auto-include branch.
+  result <- read_octron(path, method = "largest", properties = NULL)
+  expect_named(
+    result,
+    c("track", "time", "label", "confidence", "keypoint", "x", "y"),
+    ignore.order = TRUE
+  )
+})
+
+test_that("read_octron `properties = c(...)` reads only the listed columns", {
+  path <- test_path("data/octron", "octron_sample.csv")
+  result <- read_octron(
+    path,
+    method = "largest",
+    properties = c("area", "orientation")
+  )
+  expect_named(
+    result,
+    c(
+      "track", "time", "label", "confidence", "keypoint", "x", "y",
+      "area", "orientation"
+    ),
+    ignore.order = TRUE
+  )
+})
+
+test_that("read_octron warns on unknown `properties` and ignores them", {
+  path <- test_path("data/octron", "octron_sample.csv")
+  expect_warning(
+    result <- read_octron(
+      path,
+      method = "largest",
+      properties = c("area", "not_a_real_property")
+    ),
+    "Unknown"
+  )
+  expect_true("area" %in% names(result))
+  expect_false("not_a_real_property" %in% names(result))
+})
+
+test_that("read_octron rejects non-character `properties`", {
+  path <- test_path("data/octron", "octron_sample.csv")
+  expect_error(read_octron(path, properties = 1L))
+  expect_error(read_octron(path, properties = TRUE))
+})
+
+test_that("read_octron auto-includes `area` for method = 'weighted'", {
+  path <- test_path("data/octron", "octron_sample.csv")
+  expect_message(
+    result <- read_octron(
+      path,
+      method = "weighted",
+      properties = c("eccentricity")
+    ),
+    "Including.*area"
+  )
+  expect_true("area" %in% names(result))
+  expect_true("eccentricity" %in% names(result))
+})
+
+test_that("read_octron does not auto-include `area` when method = 'largest'", {
+  path <- test_path("data/octron", "octron_sample.csv")
+  expect_no_message(
+    result <- read_octron(
+      path,
+      method = "largest",
+      properties = c("eccentricity")
+    )
+  )
+  expect_false("area" %in% names(result))
+  expect_true("eccentricity" %in% names(result))
+})
+
+test_that("read_octron normalises hyphens to underscores in property names", {
+  # Octron emits scikit-image property expansions like `moments_hu-0`.
+  # We rename those to `moments_hu_0` so they're addressable as bare
+  # identifiers in the returned aniframe.
+  path <- tempfile(fileext = ".csv")
+  on.exit(unlink(path), add = TRUE)
+  writeLines(
+    c(
+      "video_name: t.mp4",
+      "frame_count: 1",
+      "frame_count_analyzed: 1",
+      "video_height: 1000",
+      "video_width: 1000",
+      "created_at: 2026",
+      paste0(
+        "frame_counter,frame_idx,track_id,label,confidence,",
+        "pos_x,pos_y,bbox_area,bbox_x_min,bbox_x_max,bbox_y_min,bbox_y_max,",
+        "moments_hu-0,moments_hu-1,moments_hu-2"
+      ),
+      "0,0,1,worm,0.9,100,200,1000,80,120,180,220,0.1,0.2,0.3"
+    ),
+    path
+  )
+  result <- read_octron(path, method = "largest")
+  expect_true("moments_hu_0" %in% names(result))
+  expect_true("moments_hu_1" %in% names(result))
+  expect_false(any(grepl("-", names(result))))
+  # And the user can request them by their underscored names:
+  picked <- read_octron(path, method = "largest", properties = "moments_hu_0")
+  expect_true("moments_hu_0" %in% names(picked))
+  expect_false("moments_hu_1" %in% names(picked))
 })


### PR DESCRIPTION
## Summary

- Vectorise `parse_octron_column()` and the multi-segment resolvers (`resolve_weighted`, `resolve_largest`, `resolve_area_sum`); skip the keypoint pivot when `keep_bbox = FALSE`; disable vroom's ALTREP wrappers on tuple-heavy character cols. End-to-end `read_octron()` on a 1.85M-row tuple-heavy file goes from "unusably slow" to a few minutes.
- New `properties` argument selects which scikit-image / Octron region-property columns to read. Defaults to `"all"` (no behaviour change). Pass a character vector for a subset, or `NULL` to skip them entirely. Selection is pushed down to `vroom::vroom(col_select)` so unread columns cost neither I/O nor parse time. `area` is auto-included with an info message when `method = "weighted"` and the user omitted it.
- Hyphens in column names are normalised to underscores (`moments_hu-0` → `moments_hu_0`) so scikit-image's expanded property names are addressable as bare R identifiers.
- Fix a latent recycling bug in `resolve_weighted()` when a row's value and area columns have different segment counts. Previously emitted opaque *"longer object length is not a multiple of shorter object length"* warnings (one per element) and silently recycled `v * a`. Now detects the mismatch, falls back to the arithmetic mean of values for those rows, and emits one summarised warning per file naming the affected `frame_idx` values.
- Bump version to 0.4.1 (DESCRIPTION, CITATION.cff, inst/CITATION) and add the NEWS section.

## Test plan

- [x] `testthat::test_dir("tests/testthat")` — all 134 tests pass (only platform-conditional skips on Windows / CRAN).
- [x] New tests cover: vectorised parser edge cases (whitespace, length-3 tuples, mixed scalar/tuple in one column); mismatch warning + mean fallback in `resolve_weighted`; `resolve_largest` realignment on mismatched lengths; partial-NA preservation; full-pipeline `read_octron()` on a 3-segment-vs-2-segment fixture; `properties = "all" | NULL | c(...)` selection; unknown-property warning; non-character `properties` rejection; `area` auto-include for `method = "weighted"`; hyphen-to-underscore name normalisation.
- [x] Bench script in `tests/perf/bench-read_octron.R` (manual; not part of the automated suite) for synthetic tuple-heavy CSVs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)