### PR TITLE
Inherit shared pkgdown theming from animovementtemplate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Suggests:
     withr
 Additional_repositories: https://animovement.r-universe.dev, 'https://bioc.r-universe.dev'
 Config/testthat/edition: 3
+Config/Needs/website: animovement/animovementtemplate
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Config/roxygen2/version: 8.0.0

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,30 +2,11 @@ url: http://animovement.dev/aniread/
 home:
   title: "aniread – An R package for reading and writing movement data"
 
-authors:
-  - name: "Mikkel Roald‑Arbøl"
-    href: "https://roald-arboel.com"
-
+# Shared navbar (incl. the animovement dropdown + Zulip), theme, and author
+# details are inherited from animovementtemplate.
 template:
   bootstrap: 5
-  light-switch: true
-
-navbar:
-  structure:
-    left:
-      - intro
-      - reference
-      - news
-    right:
-      - search
-      - github
-      - zulip
-      - lightswitch
-  components:
-    zulip:
-      icon: fa-comments
-      href: https://animovement.zulipchat.com
-      aria-label: Chat on Zulip
+  package: animovementtemplate
 
 reference:
 - title: "Reader functions"


### PR DESCRIPTION
## Summary

Brings the aniread pkgdown site in line with aniframe, anivis, and anicheck by inheriting the shared theming from the `animovementtemplate` package instead of maintaining a bespoke config.

- `_pkgdown.yml`: replaced the package-local `template`, `navbar`, and `authors` blocks with `template.package: animovementtemplate`. The navbar (including the animovement ecosystem dropdown and the Zulip link), the light-switch theme, and the author details are now inherited from the template package, so they live in one place across the ecosystem. The `url`, home title, and `reference` sections remain package-specific.
- `DESCRIPTION`: added `Config/Needs/website: animovement/animovementtemplate` (there was no `Config/Needs/website` line before) so the template package is installed when the site is built.

The existing pkgdown workflow already uses `needs: website` with `local::.`, so the GitHub-remote template installs without any workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)